### PR TITLE
SuperFence extension for mkdocs requires the pymdown-extensions python package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,5 +2,5 @@ FROM python:3.8-slim
 
 RUN apt-get update && apt-get install -y --no-install-recommends curl
 
-RUN pip install mkdocs
+RUN pip install mkdocs pymdown-extensions
 RUN sed -i '/^CipherString/d' /etc/ssl/openssl.cnf


### PR DESCRIPTION
The built in codeblock fencing within mkdocs does not handle indented code blocks correctly, but the SuperFence extension does. The SuperFence extension requires the pymdown-extensions python package in order to build the site, so this needs to be included in the docker container where mkdocs builds the HTML pages for us.

Check diffs and merge.
