### PR TITLE
Rendering of list indentation is incorrect unless mdx_truly_sane_lists extension is enabled.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,5 +2,5 @@ FROM python:3.8-slim
 
 RUN apt-get update && apt-get install -y --no-install-recommends curl
 
-RUN pip install mkdocs pymdown-extensions
+RUN pip install mkdocs pymdown-extensions mdx_truly_sane_lists
 RUN sed -i '/^CipherString/d' /etc/ssl/openssl.cnf


### PR DESCRIPTION
mkdocs does not render indented lists correctly unless this extension is enabled.